### PR TITLE
Use `accumulate!` from Base instead of Iterators

### DIFF
--- a/src/cavity.jl
+++ b/src/cavity.jl
@@ -5,7 +5,7 @@ function cavity!(dest, source, op, init)
         @inbounds dest[begin] = init 
         return op(first(source), init)
     end
-    Iterators.accumulate!(op, dest, source)
+    accumulate!(op, dest, source)
     full = op(dest[end], init)
     right = init
     for (i,s)=zip(lastindex(dest):-1:firstindex(dest)+1,Iterators.reverse(source))


### PR DESCRIPTION
For some reason, `Iterators.accumulate!` does not exist in v1.9, replaced it with `accumulate!`