### PR TITLE
Bump v 0.2.2 to meet registration guidelines

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CavityTools"
 uuid = "217fe2f1-7e3d-419f-9934-cd6900c2759a"
 authors = ["Alfredo Braunstein <alfredo.braunstein@polito.it> and contributors"]
-version = "0.2.3"
+version = "0.2.2"
 
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
The latest update (#6) was worth a new version but the update didn't go through (see [here](https://github.com/JuliaRegistries/General/pull/83350#issuecomment-1543590858)) because apparently we skipped version 0.2.2 and went directly to 0.2.3. 
Go back to 0.2.2 and trigger registrator again?