### PR TITLE
cavity accepting iterators besides vectors

### DIFF
--- a/src/cavity.jl
+++ b/src/cavity.jl
@@ -42,9 +42,9 @@ function _accumulate!(op, dest, source)
     v1 = first(source)
     dest[begin] = v1
     cur_val = v1
-    @inbounds for (i, di) in Iterators.drop(pairs(source), 1)
+    @inbounds for (i, di) in Iterators.drop(enumerate(source), 1)
         cur_val = op(cur_val, di)
-        dest[i] = cur_val
+        dest[begin+i-1] = cur_val
     end
     return dest
 end

--- a/src/cavity.jl
+++ b/src/cavity.jl
@@ -40,7 +40,7 @@ end
 function _accumulate!(op, dest, source)
     isempty(source) && return dest
     v1 = first(source)
-    dest[begin] = v1
+    @inbounds dest[begin] = v1
     cur_val = v1
     @inbounds for (i, di) in Iterators.drop(enumerate(source), 1)
         cur_val = op(cur_val, di)

--- a/src/cavity.jl
+++ b/src/cavity.jl
@@ -36,18 +36,6 @@ end
     op(first(L), first(R)), (i + 1, L, R)
 end
 
-"A homemade version of `Base.accumulate!` that accepts an iterator as `source`"
-function _accumulate!(op, dest, source)
-    isempty(source) && return dest
-    v1 = first(source)
-    @inbounds dest[begin] = v1
-    cur_val = v1
-    @inbounds for (i, di) in Iterators.drop(enumerate(source), 1)
-        cur_val = op(cur_val, di)
-        dest[begin+i-1] = cur_val
-    end
-    return dest
-end
 
 function cavity!(dest, source, op, init)
     @assert length(dest) == length(source)
@@ -56,7 +44,7 @@ function cavity!(dest, source, op, init)
         @inbounds dest[begin] = init
         return op(first(source), init)
     end
-    _accumulate!(op, dest, source)
+    copyto!(dest, Iterators.accumulate(op, source))
     full = op(dest[end], init)
     right = init
     for (i,s)=zip(lastindex(dest):-1:firstindex(dest)+1,Iterators.reverse(source))

--- a/src/cavity.jl
+++ b/src/cavity.jl
@@ -36,6 +36,19 @@ end
     op(first(L), first(R)), (i + 1, L, R)
 end
 
+"A homemade version of `Base.accumulate!` that accepts an iterator as `source`"
+function _accumulate!(op, dest, source)
+    isempty(source) && return dest
+    v1 = first(source)
+    dest[begin] = v1
+    cur_val = v1
+    @inbounds for (i, di) in Iterators.drop(pairs(source), 1)
+        cur_val = op(cur_val, di)
+        dest[i] = cur_val
+    end
+    return dest
+end
+
 function cavity!(dest, source, op, init)
     @assert length(dest) == length(source)
     isempty(source) && return init
@@ -43,7 +56,7 @@ function cavity!(dest, source, op, init)
         @inbounds dest[begin] = init
         return op(first(source), init)
     end
-    accumulate!(op, dest, source)
+    _accumulate!(op, dest, source)
     full = op(dest[end], init)
     right = init
     for (i,s)=zip(lastindex(dest):-1:firstindex(dest)+1,Iterators.reverse(source))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,6 +84,13 @@ end
     @test cavity([1],+,0) == ([0], 1)
 end
 
+@testset "cavity with iterator" begin
+    r = rand(1:10^4,10^4+11)
+    source_itr = (sqrt(x) for x in r)
+    source_vec = collect(source_itr)
+    @test cavity(source_itr, +, 0.0) == cavity(source_vec, +, 0.0)
+end
+
 @testset "ExponentialQueue" begin
     e = ExponentialQueue([5=>10.0, 10=>0.0])
     i,t = peek(e)


### PR DESCRIPTION
Allows to use `cavity!(dest, source, op init)`, with `source` a lazy iterator. 
This is useful e.g. for efficient implementation of Belief Propagation.

I had to define a custom version of `Base.accumulate!`, because the stdlib version assumes the object to be accumulated to be indexable, which iterators are not. Maybe not the wisest thing to replace stdlib code, but tests are passing...